### PR TITLE
fix: reverting #110 after export created

### DIFF
--- a/chess-centre-app/amplify/backend/function/platformchesscentreappPostConfirmation/platformchesscentreappPostConfirmation-cloudformation-template.json
+++ b/chess-centre-app/amplify/backend/function/platformchesscentreappPostConfirmation/platformchesscentreappPostConfirmation-cloudformation-template.json
@@ -100,6 +100,30 @@
             },
             "GROUP": {
               "Ref": "GROUP"
+            },
+            "GRAPHQLID": {
+              "Fn::ImportValue": {
+                "Fn::Join": [
+                  ":",
+                  [
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "api",
+                          {
+                            "Ref": "AppSyncApiName"
+                          }
+                        ]
+                      ]
+                    },
+                    {
+                      "Ref": "env"
+                    },
+                    "StaticGraphQLApiId"
+                  ]
+                ]
+              }
             }
           }
         },

--- a/chess-centre-app/amplify/backend/function/platformchesscentreappPreTokenGeneration/platformchesscentreappPreTokenGeneration-cloudformation-template.json
+++ b/chess-centre-app/amplify/backend/function/platformchesscentreappPreTokenGeneration/platformchesscentreappPreTokenGeneration-cloudformation-template.json
@@ -93,6 +93,30 @@
             },
             "REGION": {
               "Ref": "AWS::Region"
+            },
+            "GRAPHQLID": {
+              "Fn::ImportValue": {
+                "Fn::Join": [
+                  ":",
+                  [
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "api",
+                          {
+                            "Ref": "AppSyncApiName"
+                          }
+                        ]
+                      ]
+                    },
+                    {
+                      "Ref": "env"
+                    },
+                    "StaticGraphQLApiId"
+                  ]
+                ]
+              }
             }
           }
         },


### PR DESCRIPTION
@matt-d-webb this is the follow-up PR to be merged after #110 has made it all the way into `master` and the Amplify builds have succeeded. Once the Amplify builds are all green with #110 in place, we should then merge this PR (effectively reverting #110, but now with the static export in place) all the way through to `master` as well.

If you have any hesitation or questions, we can walk through this tomorrow or Monday live, on a call. Otherwise, if you feel good about the steps, feel free to merge away.

**The Steps:**
1. Merge #110 into `develop`
2. Wait for Amplify Backend build in `staging` to go green ✅ (as well as the frontend `develop` environment) 
3. Merge `develop` into `master`
4. Wait for Amplify Backend build in `prod` to go green ✅ (as well as the frontend `master` environment)
5. Merge #111 (this PR) into `develop` (be sure to change the base branch in GitHub to `develop` first; I have it pointed at the other PRs branch for now for clarity of the diff)
6. Repeat steps 2-4
7. Profit 💰 